### PR TITLE
Add basic readme doc for install and setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,118 @@
+# Quick Start
+
+## Requirements
+
+* macOS / Linux / Windows
+* Docker
+* Docker-compose
+* Golang (1.15+)
+
+## Install Tatanka
+
+Clone from github into your `$GOPATH`:
+
+```
+$ git clone https://github.com/cpurta/tatanka
+```
+
+Build the linux tatanka binary:
+
+```
+$ make tatanka
+```
+
+## Configure tatanka
+
+There is currently a sample config in the project root called `sample-config.yaml`.
+You will need to create a new `config.yaml` with your coinbase api key, secret and
+passphrase.
+
+```
+$ cp ./sample-config.yaml ./config.yaml
+```
+
+Fill in the following fields with your credentials in the `config.yaml` file:
+
+ - `api_key`
+ - `api_secret`
+ - `api_passphrase`
+
+```yaml
+cassandra:
+  cluster:
+    - "cassandra"
+  keyspace: "tatanka"
+
+gdax:
+  api_key: "your_gdax_api_key"
+  api_secret: "your_gdax_api_secret"
+  api_passphrase: "your_gdax_api_passphrase"
+```
+
+Once you have entered your credentials tatanka should be able to successfully connect
+to the Coinbase API to then pull account balance information and be able to live
+trade if allowed.
+
+## Running in Docker
+
+Currently tatanka is configured to run in docker and a docker compose environment.
+Although you can set up tatanka to run locally if will require you to run a Cassandra
+cluster on your machine and point tatanka to connect to that cluster. For now it
+is recommended you use the docker-compose environment.
+
+### Build
+
+You can build the necessary docker images by running the following command:
+
+```
+$ docker-compose -f ./docker/docker-compose.yml build
+```
+
+Or alternately you can use the `make build` command:
+
+```
+$ make build
+```
+
+### Run
+
+Since tatanka is running in docker-compose you can run or execute tatanka commands
+by running those through docker-compose commands.
+
+#### Examples
+
+**Balance:**
+
+```
+$ docker-compose -f ./docker/docker-compose.yml run tatanka balance gdax.BTC-USD
+```
+
+**List Strategies**
+
+```
+$ docker-compose -f ./docker/docker-compose.yml run tatanka list-strategies
+```
+
+**List Selectors**
+
+```
+$ docker-compose -f ./docker/docker-compose.yml run tatanka list-selectors
+```
+
+**Simulate Strategy**
+
+```
+$ docker-compose -f ./docker/docker-compose.yml run tatanka sim gdax.BTC-USD
+```
+
+**Backfill Historical Data**
+
+```
+$ docker-compose -f ./docker/docker-compose.yml run tatanka backfill gdax.BTC-USD
+```
+
+**Live/Paper Trade on Live Market Data**
+
+```
+$ docker-compose -f ./docker/docker-compose.yml run tatanka trade gdax.BTC-USD
+```

--- a/docs/commands/backfill.md
+++ b/docs/commands/backfill.md
@@ -1,0 +1,13 @@
+```
+NAME:
+   tatanka backfill - download historical trades for analysis
+
+USAGE:
+   tatanka backfill [command options] [arguments...]
+
+OPTIONS:
+   --config value  path to optional config overrides file (default: "/etc/tatanka/config.yaml")
+   --days value    number of days to acquire (default: 1)
+   --debug         output detailed debug info (default: false)
+   --help, -h      show help (default: false)
+```

--- a/docs/commands/balance.md
+++ b/docs/commands/balance.md
@@ -1,0 +1,12 @@
+```
+NAME:
+   tatanka balance - get asset and currency balance from the exchange
+
+USAGE:
+   tatanka balance [command options] [arguments...]
+
+OPTIONS:
+   --config value        path to optional config overrides file (default: "/etc/tatanka/config.yaml")
+   --calculate_currency  show the full balance in another currency (default: false)
+   --help, -h            show help (default: false)
+```

--- a/docs/commands/list-strategies.md
+++ b/docs/commands/list-strategies.md
@@ -1,0 +1,15 @@
+```
+rsi
+    description:
+        Attempts to buy low and sell high by tracking RSI high-water readings.
+    options:
+        --period=<value>   period length, same as --period_length (default: 2m0s)
+        --period_length=<value>   period length, same as --period (default: 2m0s)
+        --min_periods=<value>   min. number of history periods (default: 52)
+        --rsi_periods=<value>   number of RSI periods (default: 14)
+        --oversold_rsi=<value>   buy when RSI reaches or drops below this value (default: 30)
+        --overbought_rsi=<value>   sell when RSI reaches or goes above this value (default: 82)
+        --rsi_recover=<value>   allow RSI to recover this many points before buying (default: 3)
+        --rsi_drop=<value>   allow RSI to fall this many points before selling (default: 0)
+        --rsi_divisor=<value>   sell when RSI reaches high-water reading divided by this value (default: 2)
+```

--- a/docs/commands/sim.md
+++ b/docs/commands/sim.md
@@ -1,0 +1,41 @@
+```
+NAME:
+   tatanka sim - run a simulation on backfilled data
+
+USAGE:
+   tatanka sim [command options] [arguments...]
+
+OPTIONS:
+   --config value                  path to optional config overrides file (default: "/etc/tatanka/config.yaml")
+   --strategy value                strategy to use (default: "trend_ema")
+   --order_type value              order type to use (maker/taker) (default: "maker")
+   --filename value                filename for the result output (ex: result.html). "none" to disable
+   --days value                    set duration by day count (default: 14)
+   --currency_capital value        amount of start capital in currency (default: 1000)
+   --asset_capital value           amount of start capital in asset (default: 0)
+   --avg_slippage_pct value        avg. amount of slippage to apply to trades (default: 0.045)
+   --buy_pct value                 buy with this % of currency balance (default: 99)
+   --sell_pct value                sell with this % of asset balance (default: 99)
+   --markdown_buy_pct value        % to mark down buy price (default: 0)
+   --markdown_sell_pct value       % to mark up sell price (default: 0)
+   --order_adjust_time value       adjust bid/ask on this interval to keep orders competitive in ms (default: 5000)
+   --order_poll_time value         poll order status on this interval in ms (default: 5000)
+   --sell_cancel_pct value         cancels the sale if the price is between this percentage (for more or less) (default: 0)
+   --sell_stop_pct value           sell if price drops below this % of bought price (default: 0)
+   --buy_stop_pct value            buy if price surges above this % of sold price (default: 0)
+   --profit_stop_enable_pct value  enable trailing sell stop when reaching this % profit (default: 0)
+   --profit_stop_pct value         maintain a trailing stop this % below the high-water mark of profit (default: 1)
+   --max_sell_loss_pct value       avoid selling at a loss pct under this float (default: 99)
+   --max_buy_loss_pct value        avoid buying at a loss pct over this float (default: 99)
+   --max_slippage_pct value        avoid selling at a slippage pct above this float (default: 5)
+   --rsi_periods value             number of periods to calculate RSI at (default: 14)
+   --exact_buy_orders              instead of only adjusting maker buy when the price goes up, adjust it if price has changed at all (default: false)
+   --exact_sell_orders             instead of only adjusting maker sell when the price goes down, adjust it if price has changed at all (default: false)
+   --disable_options               disable printing of options (default: false)
+   --quarentine_time value         For loss trade, set quarentine time for cancel buys in minutes (default: 10)
+   --enable_stats                  enable printing order stats (default: false)
+   --backtester_generation value   creates a json file in simulations with the generation number (default: -1)
+   --verbose                       print status lines on every period (default: false)
+   --silent                        only output on completion (can speed up sim) (default: false)
+   --help, -h                      show help (default: false)
+```

--- a/docs/commands/trade.md
+++ b/docs/commands/trade.md
@@ -1,0 +1,42 @@
+```
+NAME:
+   tatanka trade - run trading bot against live market data
+
+USAGE:
+   tatanka trade [command options] [arguments...]
+
+OPTIONS:
+   --config value                  path to optional config overrides file (default: "/etc/tatanka/config.yaml")
+   --strategy value                strategy to use (default: "trend_ema")
+   --order_type value              order type to use (maker/taker) (default: "maker")
+   --filename value                filename for the result output (ex: result.html). "none" to disable
+   --days value                    set duration by day count (default: 14)
+   --currency_capital value        amount of start capital in currency (default: 1000)
+   --asset_capital value           amount of start capital in asset (default: 0)
+   --avg_slippage_pct value        avg. amount of slippage to apply to trades (default: 0.045)
+   --buy_pct value                 buy with this % of currency balance (default: 99)
+   --sell_pct value                sell with this % of asset balance (default: 99)
+   --markdown_buy_pct value        % to mark down buy price (default: 0)
+   --markdown_sell_pct value       % to mark up sell price (default: 0)
+   --order_adjust_time value       adjust bid/ask on this interval to keep orders competitive in ms (default: 5000)
+   --order_poll_time value         poll order status on this interval in ms (default: 5000)
+   --sell_cancel_pct value         cancels the sale if the price is between this percentage (for more or less) (default: 0)
+   --sell_stop_pct value           sell if price drops below this % of bought price (default: 0)
+   --buy_stop_pct value            buy if price surges above this % of sold price (default: 0)
+   --profit_stop_enable_pct value  enable trailing sell stop when reaching this % profit (default: 0)
+   --profit_stop_pct value         maintain a trailing stop this % below the high-water mark of profit (default: 1)
+   --max_sell_loss_pct value       avoid selling at a loss pct under this float (default: 99)
+   --max_buy_loss_pct value        avoid buying at a loss pct over this float (default: 99)
+   --max_slippage_pct value        avoid selling at a slippage pct above this float (default: 5)
+   --rsi_periods value             number of periods to calculate RSI at (default: 14)
+   --exact_buy_orders              instead of only adjusting maker buy when the price goes up, adjust it if price has changed at all (default: false)
+   --exact_sell_orders             instead of only adjusting maker sell when the price goes down, adjust it if price has changed at all (default: false)
+   --disable_options               disable printing of options (default: false)
+   --quarentine_time value         For loss trade, set quarentine time for cancel buys in minutes (default: 10)
+   --enable_stats                  enable printing order stats (default: false)
+   --backtester_generation value   creates a json file in simulations with the generation number (default: -1)
+   --verbose                       print status lines on every period (default: false)
+   --paper                         use paper trading mode (no real trades will take place) (default: false)
+   --silent                        only output on completion (can speed up sim) (default: false)
+   --help, -h                      show help (default: false)
+```


### PR DESCRIPTION
Added a basic README doc that outlines installation, configuration and setup in docker compose. This should also include the commands help/usage.