### PR TITLE
Update makefile with more commands for ease of use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
+tatanka:
+	GOOS=linux GOARCH=amd64 go build -o ./docker/artifacts/tatanka ./cmd/tatanka
+
 ## Generates mock golang interfaces for testing
 mock:
 	go install github.com/golang/mock/mockgen
 	mockgen -destination internal/cassandra/mock_cassandra/mock.go github.com/cpurta/tatanka/internal/cassandra Client
 
-.PHONY: test
+.PHONY: test image
 test:
 	go test ./...
 
-all: mock test
+image:
+	docker-compose -f ./docker/docker-compose.yml build
+
+run:
+	docker-compose -f ./docker/docker-compose.yml run tatanka
+
+all: mock test tatanka image run


### PR DESCRIPTION
Add make targets for the following:
- build tatanka linux binary
- build docker image(s)
- run the tatanka docker images in the docker compose environment
- Add all of those to the 'all' target